### PR TITLE
Use browser's local time instead of UTC time

### DIFF
--- a/temperature_log.htm
+++ b/temperature_log.htm
@@ -34,6 +34,11 @@
    <script type="text/javascript">
    // Configure the plot
    $(document).ready(function() {
+      Highcharts.setOptions({
+          global: {
+              useUTC: false
+          }
+      });
       chart = new Highcharts.Chart({
          chart: {
             renderTo: 'container',

--- a/temperature_plot.htm
+++ b/temperature_plot.htm
@@ -29,6 +29,12 @@
 	<script type="text/javascript">
    // Configure the plot
 	$(document).ready(function() {
+      Highcharts.setOptions({
+          global: {
+              useUTC: false
+          }
+      });
+
 	   chart = new Highcharts.Chart({
 		chart: {
 		    renderTo: 'container',

--- a/temperature_plot.htm
+++ b/temperature_plot.htm
@@ -29,11 +29,11 @@
 	<script type="text/javascript">
    // Configure the plot
 	$(document).ready(function() {
-      Highcharts.setOptions({
-          global: {
-              useUTC: false
-          }
-      });
+		Highcharts.setOptions({
+			global: {
+				useUTC: false
+			}
+		});
 
 	   chart = new Highcharts.Chart({
 		chart: {


### PR DESCRIPTION
I found that the client demo displayed the UTC time instead of my local time. This can be fixed using Highcharts.setOptions.
